### PR TITLE
CBL-4521: XCode 14.3 Error : variable 't' set but not used in mbedtls's bignum.c

### DIFF
--- a/library/bignum.c
+++ b/library/bignum.c
@@ -1388,7 +1388,7 @@ void mpi_mul_hlp( size_t i,
                   mbedtls_mpi_uint *d,
                   mbedtls_mpi_uint b )
 {
-    mbedtls_mpi_uint c = 0, t = 0;
+    mbedtls_mpi_uint c = 0;
 
 #if defined(MULADDC_HUIT)
     for( ; i >= 8; i -= 8 )
@@ -1438,8 +1438,6 @@ void mpi_mul_hlp( size_t i,
         MULADDC_STOP
     }
 #endif /* MULADDC_HUIT */
-
-    t++;
 
     while( c != 0 )
     {


### PR DESCRIPTION
There's a defined variable that is set but never used. Since Xcode/Command Line Tools 14.3, this causes a compile error in this library and any that depend on it (LiteCore). 