### PR TITLE
Enable MBEDTLS_THREADING_C [CBL-6649]

### DIFF
--- a/include/mbedtls/config.h
+++ b/include/mbedtls/config.h
@@ -2259,6 +2259,7 @@
  * Uncomment this to allow your own alternate threading implementation.
  */
 //#define MBEDTLS_THREADING_ALT
+// FIXME: Need to define MBEDTLS_THREADING_ALT on Windows and implement mutex functions --Jens
 
 /**
  * \def MBEDTLS_THREADING_PTHREAD
@@ -2269,7 +2270,9 @@
  *
  * Uncomment this to enable pthread mutexes.
  */
-//#define MBEDTLS_THREADING_PTHREAD
+#ifndef _WIN32
+#define MBEDTLS_THREADING_PTHREAD
+#endif
 
 /**
  * \def MBEDTLS_USE_PSA_CRYPTO
@@ -3622,7 +3625,9 @@
  *
  * Enable this layer to allow use of mutexes within Mbed TLS
  */
-//#define MBEDTLS_THREADING_C
+#ifndef _WIN32  // FIXME: Remove this when implementing threading for Windows --Jens
+#define MBEDTLS_THREADING_C
+#endif
 
 /**
  * \def MBEDTLS_TIMING_C


### PR DESCRIPTION
LiteCore needs mbedTLS to be thread-safe since it shares `ssl_config` instances between threads.

This commit fixes the problem for platforms other than Windows. Unfortunately mbedTLS only has direct support for pthreads; to use a different threading API you have to define `MBEDTLS_THREADING_ALT` and provide some functions.

Fixes CBL-6649