### PR TITLE
Changes needed for Windows threading abstraction

### DIFF
--- a/include/mbedtls/mbedtls_config.h
+++ b/include/mbedtls/mbedtls_config.h
@@ -2169,7 +2169,7 @@
  * Uncomment this to allow your own alternate threading implementation.
  */
 //#define MBEDTLS_THREADING_ALT
-// FIXME: Need to define MBEDTLS_THREADING_ALT on Windows and implement mutex functions --Jens
+// NOTE: Use config.py to uncomment this before Windows build
 
 /**
  * \def MBEDTLS_THREADING_PTHREAD
@@ -2180,9 +2180,8 @@
  *
  * Uncomment this to enable pthread mutexes.
  */
-#ifndef _WIN32
 #define MBEDTLS_THREADING_PTHREAD
-#endif
+// NOTE: Use config.py to comment this out before Windows build
 
 /**
  * \def MBEDTLS_USE_PSA_CRYPTO
@@ -3764,9 +3763,7 @@
  *
  * Enable this layer to allow use of mutexes within Mbed TLS
  */
-#ifndef _WIN32  // FIXME: Remove this when implementing threading for Windows --Jens
 #define MBEDTLS_THREADING_C
-#endif
 
 /**
  * \def MBEDTLS_TIMING_C


### PR DESCRIPTION
No more ifdef, but instead the consumer will need to alter the mbedtls_config.h file before building Windows.  This also eliminates the python error at build time resulting from the ifdef not being able to be processed inside of mbedtls_config.h.